### PR TITLE
var'd result value

### DIFF
--- a/weekfunctions.cfc
+++ b/weekfunctions.cfc
@@ -69,7 +69,7 @@ component
 	public struct function dateInWeek( required string d )
 		hint = "Returns a struct with the week number and year a given date belongs to."
 	{
-		result = {
+		var result = {
 			week: 0,
 			year: 0
 		};


### PR DESCRIPTION
non var'd return variable caused issues in an asynchronous workflow